### PR TITLE
Make automatic OpenHIM registration configurable

### DIFF
--- a/env/sample
+++ b/env/sample
@@ -34,6 +34,12 @@ export OPENHIM_APIURL='https://openhim.example.com/'
 # Should be True unless OpenHIM is using a self-signed certificate
 export OPENHIM_VERIFY_CERT=True
 
+# Whether to register the mediator with OpenHIM on startup
+export OPENHIM_REGISTER=True
+
+# Whether to send regular heartbeat calls to OpenHIM (requires OPENHIM_REGISTER=True)
+export OPENHIM_HEARTBEAT=True
+
 
 # Mediator settings
 
@@ -58,6 +64,7 @@ export MEDIATOR_UPSTREAM_URL="https://sampleApplication:7001"
 
 export DJANGO_SECRET_KEY='N3acC3293AlnecjLFlu5TprTlHsTYFODlM0BAW7eM4QtbBcBH7'
 export DJANGO_DEBUG=True
+
 # A space-separated list of hostnames:
 export DJANGO_ALLOWED_HOSTS=""
 

--- a/mediator/mediator/settings.py
+++ b/mediator/mediator/settings.py
@@ -24,8 +24,8 @@ OPENHIM_OPTIONS = {
     'force_config': False,
     'interval': 10,
 
-    'register': True,
-    'heartbeat': True,
+    'register': os.environ['OPENHIM_REGISTER'].lower() not in ('0', 'false', 'no'),
+    'heartbeat': os.environ['OPENHIM_HEARTBEAT'].lower() not in ('0', 'false', 'no'),
 }
 
 MEDIATOR_CONF = {


### PR DESCRIPTION
Automatic OpenHIM registration isn't always desirable. Sometimes you want to register a mediator manually. This PR makes it configurable for a deploy environment.

(The format for truthy and falsey values is given in a comment a few lines above, on line 33.)