### PR TITLE
Install openhim-mediator-utils requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ADD git-archive.tar.gz /usr/src/
 
 WORKDIR /usr/src/openhim-mediator-passthrough/
 RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r src/openhim-mediator-utils/requirements.txt
 
 ENV PYTHONUNBUFFERED 1
 ENV DJANGO_SETTINGS_MODULE mediator.settings


### PR DESCRIPTION
The dependencies of the openhim-mediator-utils library are not being installed automatically. I think it's because its [setup.py](https://github.com/de-laz/openhim-mediator-utils-py/blob/master/setup.py) file is missing the [`install_requires`](https://python-packaging.readthedocs.io/en/latest/dependencies.html) parameter.

I couldn't find a way to tell pip to install from its requirements.txt file using options inside my requirements.txt file, so I ended up adding a second `pip install` command. This seems clunky. If there is a better way to do this, please let me know.
