### PR TITLE
docker-compose.yaml environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ env/*
 git-archive.tar.gz
 Dockerrun.aws.json
 eb-artifact.zip
+docker-compose.yaml
 
 # Elastic Beanstalk Files
 .elasticbeanstalk/*

--- a/docker/templates/docker-compose.yaml
+++ b/docker/templates/docker-compose.yaml
@@ -13,6 +13,24 @@ services:
     image: openhim-mediator-passthrough
     ports:
       - "8000:4000"
+    environment:
+        OPENHIM_USERNAME: "{{ OPENHIM_USERNAME }}"
+        OPENHIM_PASSWORD: "{{ OPENHIM_PASSWORD }}"
+        OPENHIM_APIURL: "{{ OPENHIM_APIURL }}"
+        OPENHIM_VERIFY_CERT: "{{ OPENHIM_VERIFY_CERT }}"
+        MEDIATOR_URN: "{{ MEDIATOR_URN }}"
+        MEDIATOR_NAME: "{{ MEDIATOR_NAME }}"
+        MEDIATOR_DESCRIPTION: "{{ MEDIATOR_DESCRIPTION }}"
+        MEDIATOR_URL: "{{ MEDIATOR_URL }}"
+        MEDIATOR_ROUTE_0_NAME: "{{ MEDIATOR_ROUTE_0_NAME }}"
+        MEDIATOR_ROUTE_0_HOST: "{{ MEDIATOR_ROUTE_0_HOST }}"
+        MEDIATOR_ROUTE_0_PORT: "{{ MEDIATOR_ROUTE_0_PORT }}"
+        MEDIATOR_ROUTE_0_PATH: "{{ MEDIATOR_ROUTE_0_PATH }}"
+        MEDIATOR_ALLOW_ROLE: "{{ MEDIATOR_ALLOW_ROLE }}"
+        MEDIATOR_UPSTREAM_URL: "{{ MEDIATOR_UPSTREAM_URL }}"
+        DJANGO_SECRET_KEY: "{{ DJANGO_SECRET_KEY }}"
+        DJANGO_DEBUG: "{{ DJANGO_DEBUG }}"
+        DJANGO_ALLOWED_HOSTS: "{{ DJANGO_ALLOWED_HOSTS }}"
 
   mongo-db:
     container_name: mongo-db

--- a/scripts/build-compose.sh
+++ b/scripts/build-compose.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# Builds a docker-compose.yaml file
+#
+
+if [ -z "$ENVIRONMENT_NAME" ]
+then
+    echo Environment variables have not been set. Use
+    echo "    \$ source env/<target environment name>"
+    exit 1
+fi
+
+scripts/render-env.py docker/templates/docker-compose.yaml > docker-compose.yaml


### PR DESCRIPTION
The `docker-compose.yaml` file needs environment variables. This PR is to render it from a template so that the environment variables' values are set according to its environment.
