### PR TITLE
Pass the full path to the view

### DIFF
--- a/mediator/mediator/urls.py
+++ b/mediator/mediator/urls.py
@@ -13,10 +13,10 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.urls import path
+from django.urls import re_path
 
 from passthru.views import primary_route
 
 urlpatterns = [
-    path('', primary_route),
+    re_path('^.*$', primary_route),
 ]

--- a/mediator/passthru/views.py
+++ b/mediator/passthru/views.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from django.conf import settings
 from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
 
 
 def get_http_headers(request_meta):
@@ -29,6 +30,7 @@ def get_body_string(request):
 
 
 # Extend the mediator by adding more routes/views
+@csrf_exempt
 def primary_route(request):
     """
     The passthrough mediator forwards the incoming request unchanged


### PR DESCRIPTION
When OpenHIM calls the mediator, it calls it with the full path it was called with. 

For example, if CommCare HQ calls OpenHIM at "https://openhim.example.com:5000/dhis2/api/dataValueSets", and OpenHIM calls the mediator for all requests that start with the pattern "^dhis2/.*", then the mediator's `request.path` will be "/dhis2/api/dataValueSets"

This PR accepts all request paths, and POST requests without CSRF validation.
