### PR TITLE
The default EC2 instance for EB seems to be t1.micro

### DIFF
--- a/docker/templates/Dockerrun.aws.json
+++ b/docker/templates/Dockerrun.aws.json
@@ -19,7 +19,7 @@
       "name": "mediator",
       "image": "dimagi/openhim-mediator-passthrough:latest",
       "essential": true,
-      "memoryReservation": 512
+      "memoryReservation": 384
     },
     {
       "name": "nginx_certbot",
@@ -29,7 +29,7 @@
         {"name": "CERTBOT_EMAIL", "value": "{{ PROXY_CERTBOT_EMAIL }}"},
         {"name": "STAGING", "value": "{{ PROXY_CERTBOT_STAGING }}"}
       ],
-      "memoryReservation": 256,
+      "memoryReservation": 128,
       "portMappings": [
         {
           "hostPort": 80,


### PR DESCRIPTION
Drop the memory reservation. :grimacing: 
