### PR TITLE
Update sample values

### DIFF
--- a/docker/templates/docker-compose.yaml
+++ b/docker/templates/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       context: .
     image: openhim-mediator-passthrough
     ports:
-      - "8000:4000"
+      - "8000:8000"
     environment:
         OPENHIM_USERNAME: "{{ OPENHIM_USERNAME }}"
         OPENHIM_PASSWORD: "{{ OPENHIM_PASSWORD }}"

--- a/env/sample
+++ b/env/sample
@@ -27,8 +27,8 @@ fi
 export OPENHIM_USERNAME=user@example.com
 export OPENHIM_PASSWORD="secret"
 
-# The API URL of the OpenHIM instance:
-export OPENHIM_APIURL='https://openhim.example.com/'
+# The API URL of the OpenHIM instance. Omit final "/":
+export OPENHIM_APIURL='https://openhim.example.com:5000'
 
 # Valid values for False: "0", "False" or "No". All other values will be considered True.
 # Should be True unless OpenHIM is using a self-signed certificate
@@ -48,11 +48,11 @@ export MEDIATOR_NAME="Passthrough Mediator"
 export MEDIATOR_DESCRIPTION="This is a passthrough mediator"
 
 # Requests to this path will be forwarded to this mediator:
-export MEDIATOR_URL='/passthru/.*',
+export MEDIATOR_URL='^/passthru/.*$',
 
 export MEDIATOR_ROUTE_0_NAME="Passthrough Mediator Route"
 export MEDIATOR_ROUTE_0_HOST=localhost
-export MEDIATOR_ROUTE_0_PORT=4000
+export MEDIATOR_ROUTE_0_PORT=8000
 export MEDIATOR_ROUTE_0_PATH="/"
 
 export MEDIATOR_ALLOW_ROLE="Sample Role"


### PR DESCRIPTION
That forward slash is a gotcha. The URL is used by the openhim-mediator-utils library, and it doesn't strip it when it appends request paths.

We could strip it in settings.py, but ideally the library should strip it, for the sake of other users. I'll send them a PR, and if nothing happens we can strip it ourselves.

Also, for simplicity, I'm going with port 8000 instead of mapping to 4000.